### PR TITLE
Adapt mod to 1.21.4 and fix part of issue #5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.2-SNAPSHOT'
+    id 'fabric-loom' version '1.11-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -30,7 +30,7 @@ processResources {
 }
 
 java {
-    toolchain.languageVersion = JavaLanguageVersion.of(17)
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
     archivesBaseName = project.archives_base_name
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,11 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.4
-loader_version=0.15.11
-yarn_mappings=1.20.4+build.3
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.8
+loader_version=0.17.2
+fabric_version=0.119.4+1.21.4
 # Mod Properties
-mod_version=1.3.0
+mod_version=1.3.1
 maven_group=me.thosea
 archives_base_name=EatServerPacks

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/thosea/eatserverpacks/mixin/MixinConfirmScreen.java
+++ b/src/main/java/me/thosea/eatserverpacks/mixin/MixinConfirmScreen.java
@@ -39,19 +39,23 @@ public abstract class MixinConfirmScreen extends Screen {
 	@Shadow
 	protected abstract void addButton(ButtonWidget button);
 
-	private boolean esp$isResourcePack;
+	@Unique
+    private boolean esp$isResourcePack;
 
 	@Inject(method = "<init>(Lit/unimi/dsi/fastutil/booleans/BooleanConsumer;Lnet/minecraft/text/Text;Lnet/minecraft/text/Text;Lnet/minecraft/text/Text;Lnet/minecraft/text/Text;)V", at = @At("TAIL"))
 	private void onInit(BooleanConsumer booleanConsumer, Text component, Text component2, Text component3, Text component4, CallbackInfo ci) {
 		esp$isResourcePack = ((Object) this) instanceof ConfirmServerResourcePackScreen;
 	}
 
-	private ButtonWidget esp$eatPackButton;
-	private ButtonWidget esp$grabPackButton;
+	@Unique
+    private ButtonWidget esp$eatPackButton;
+	@Unique
+    private ButtonWidget esp$grabPackButton;
 
 	@SuppressWarnings("UnreachableCode") // I don't know either
 	@Inject(method = "addButtons", at = @At("TAIL"))
 	private void onAddButtons(int y, CallbackInfo ci) {
+        if (client == null) return;
 		if(!esp$isResourcePack) return;
 
 		ClientPlayNetworkHandler network = MinecraftClient.getInstance().getNetworkHandler();
@@ -101,7 +105,8 @@ public abstract class MixinConfirmScreen extends Screen {
 		return ((ConfirmServerResourcePackScreen) (Object) this).packs;
 	}
 
-	private URI esp$uriOf(Pack pack) {
+	@Unique
+    private URI esp$uriOf(Pack pack) {
 		try {
 			return pack.url().toURI();
 		} catch(URISyntaxException e) {
@@ -112,6 +117,7 @@ public abstract class MixinConfirmScreen extends Screen {
 	@Inject(method = "tick", at = @At("HEAD"))
 	private void onTick(CallbackInfo ci) {
 		if(!esp$isResourcePack) return;
+        if (esp$eatPackButton == null || esp$grabPackButton == null) return;
 
 		boolean isSneakPressed = false;
 
@@ -132,7 +138,9 @@ public abstract class MixinConfirmScreen extends Screen {
 		}
 	}
 
-	private void esp$eatServerPack() {
+	@Unique
+    private void esp$eatServerPack() {
+        if (client == null) return;
 		ClientPlayNetworkHandler network = client.getNetworkHandler();
 		if(network == null) return;
 

--- a/src/main/java/me/thosea/eatserverpacks/mixin/MixinResourcePackPolicy.java
+++ b/src/main/java/me/thosea/eatserverpacks/mixin/MixinResourcePackPolicy.java
@@ -1,10 +1,7 @@
 package me.thosea.eatserverpacks.mixin;
 
 import net.minecraft.client.network.ServerInfo.ResourcePackPolicy;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
 import java.util.ArrayList;
@@ -19,9 +16,10 @@ public class MixinResourcePackPolicy {
 		esp$makeEatPackPolicy();
 	}
 
-	private static void esp$makeEatPackPolicy() {
+	@Unique
+    private static void esp$makeEatPackPolicy() {
 		List<ResourcePackPolicy> policies = new ArrayList<>(List.of(RESOURCE_PACK_POLICIES));
-		int id = policies.get(policies.size() - 1).ordinal() + 1;
+		int id = policies.getLast().ordinal() + 1;
 		ResourcePackPolicy policy = esp$makePolicy("esp$EAT_SERVER_PACK", id, "eatserverpack");
 		policies.add(policy);
 		RESOURCE_PACK_POLICIES = policies.toArray(new ResourcePackPolicy[0]);

--- a/src/main/java/me/thosea/eatserverpacks/mixin/MixinServerInfo.java
+++ b/src/main/java/me/thosea/eatserverpacks/mixin/MixinServerInfo.java
@@ -1,5 +1,6 @@
 package me.thosea.eatserverpacks.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import me.thosea.eatserverpacks.EatServerPacks;
 import net.minecraft.client.network.ServerInfo;
 import net.minecraft.client.network.ServerInfo.ResourcePackPolicy;
@@ -16,19 +17,17 @@ public class MixinServerInfo {
 	@Shadow private ResourcePackPolicy resourcePackPolicy;
 
 	@Inject(method = "toNbt",
-			locals = LocalCapture.CAPTURE_FAILHARD,
-			at = @At("TAIL"))
-	private void onSerialize(CallbackInfoReturnable<NbtCompound> cir, NbtCompound tag) {
+            at = @At("TAIL"))
+	private void onSerialize(CallbackInfoReturnable<NbtCompound> cir, @Local NbtCompound tag) {
 		if(resourcePackPolicy == EatServerPacks.PACK_POLICY) {
 			tag.putBoolean("eatserverpacks_eatpack", true);
 		}
 	}
 
 	@Inject(method = "fromNbt",
-			locals = LocalCapture.CAPTURE_FAILHARD,
-			at = @At("TAIL"))
+            at = @At("TAIL"))
 	private static void onDeserialize(NbtCompound root, CallbackInfoReturnable<ServerInfo> cir,
-	                                  ServerInfo serverInfo) {
+                                      @Local ServerInfo serverInfo) {
 		if(root.getBoolean("eatserverpacks_eatpack")) {
 			serverInfo.setResourcePackPolicy(EatServerPacks.PACK_POLICY);
 		}

--- a/src/main/java/me/thosea/eatserverpacks/ui/ESPButton.java
+++ b/src/main/java/me/thosea/eatserverpacks/ui/ESPButton.java
@@ -27,6 +27,10 @@ public final class ESPButton extends ButtonWidget {
 		this.setTooltip(Tooltip.of(tooltip));
 	}
 
+    private boolean clicked(double mouseX, double mouseY) {
+        return this.active && this.visible && mouseX >= (double)this.getX() && mouseY >= (double)this.getY() && mouseX < (double)(this.getX() + this.getWidth()) && mouseY < (double)(this.getY() + this.getHeight());
+    }
+
 	@Override
 	public boolean mouseClicked(double mouseX, double mouseY, int button) {
 		if(!active || !visible) return false;

--- a/src/main/resources/eatserverpacks.mixins.json
+++ b/src/main/resources/eatserverpacks.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "me.thosea.eatserverpacks.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "injectors": {
     "defaultRequire": 1
   },


### PR DESCRIPTION
### Changes

1. Adapted gradle configuration and mixins to Minecraft 1.21.4.
2. Partial fix for issue #5: prevents game crash when server requests resource packs.

> Note: The issue is not fully resolved; this fix ensures the mod no longer crashes.

### Related issue
Partial fix for #5

Note: Upstream does not currently have a 1.21.4 branch.
It's recommended to create a new branch `1.21.4` in the upstream repo before merging these changes.